### PR TITLE
Update vulnerable dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       ruby_dep (~> 1.2)
     loofah (2.2.2)
       crass (~> 1.0.2)
-      nokogiri (>= 1.8.2)
+      nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)


### PR DESCRIPTION
story: https://trello.com/c/HDVfXN8t

I think the issue with loofah updating on production is with the dependency version of `nokogiri`. I ran the update command for `loofah` gem file and it changed the dependency for `nokogiri` down to 1.5.9 version.